### PR TITLE
Add support for IndexMap and IndexSet in FeattleValue implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ version = "3.0.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "indexmap",
  "log",
  "parking_lot",
  "serde",

--- a/feattle-core/Cargo.toml
+++ b/feattle-core/Cargo.toml
@@ -22,9 +22,13 @@ serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "2.0.12"
 uuid = { version = "1.1.2", optional = true }
+indexmap = { version = "2.0.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.4.0", features = ["macros", "rt"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[features]
+default = ["uuid", "indexmap"]

--- a/feattle-core/Cargo.toml
+++ b/feattle-core/Cargo.toml
@@ -29,6 +29,3 @@ tokio = { version = "1.4.0", features = ["macros", "rt"] }
 
 [package.metadata.docs.rs]
 all-features = true
-
-[features]
-default = ["uuid", "indexmap"]


### PR DESCRIPTION
Add support for IndexMap and IndexSet in FeattleValue implementation

## Description

We need support of IndexMap and IndexSet at iFood so we can parse toggles as these data structures.

I'm new to Rust and I am feeling that I may be overusing macros. Please let me know if that is the case, with a suggestion of how to avoid duplication in implementations of BTreeMap with IndexMap, or BTreeSet with IndexSet, if we should avoid at all.

## Checklist

- [x] I have read
[CONTRIBUTING](https://github.com/sitegui/feattle-rs/blob/master/docs/CONTRIBUTING.md)
guidelines.
- [ ] I have formatted the code using [rustfmt](https://github.com/rust-lang/rustfmt)
- [ ] I have checked that all tests pass, by running `cargo test --all`

#### [CHANGELOG](https://github.com/sitegui/feattle-rs/blob/master/CHANGELOG.md):

- [ ] Updated
- [x] I will update it after this PR has been discussed
- [ ] No need to update
